### PR TITLE
Modification to generate pdfs with one slide per page

### DIFF
--- a/server/pjs_printpdf.js
+++ b/server/pjs_printpdf.js
@@ -6,9 +6,8 @@ var page = require('webpage').create(),
 
     address = system.args[1];
     output = system.args[2];
-    page.viewportSize = { width: 600, height: 600 };
-    page.paperSize = { format: 'A4', orientation: 'portrait', margin: '2.3cm' };
-    page.zoomFactor = 1.5;
+    page.viewportSize = { width: 800, height: 600 };
+    page.paperSize = { width:"800px", height:"600px" };
 
     page.open(address, function (status) {
         if (status !== 'success') {

--- a/server/server.js
+++ b/server/server.js
@@ -111,7 +111,7 @@ http.createServer(
 		);
 
 		// create pdf 
-		if (urlp.pathname.match("^.*/lecture[0-9]{1,2}\.pdf$")) {
+		if (urlp.pathname.match("^.*\.pdf$")) {
 			// check if pdf exists and if the date matches the html date
 			fpdf = config.PUBLIC_HTML + "" + urlp.pathname;
 			fhtm = config.PUBLIC_HTML + "" + urlp.pathname.replace(".pdf", ".html");

--- a/server/server.js
+++ b/server/server.js
@@ -46,7 +46,7 @@ http.createServer(
 	    // ajax crawling of a single humla slide
 	    if (urlp.query && urlp.query["_escaped_fragment_"]) {
 	    	// URL to request AJAX content based from AXAJ crawling request
-	 		hurl = "http://" + config.HOSTNAME + "/" + urlp.pathname + "#" + urlp.query["_escaped_fragment_"];
+	 		hurl = "http://" + config.HOSTNAME + ":" + config.SERVER_PORT + "/" + urlp.pathname + "#" + urlp.query["_escaped_fragment_"];
 			config.execute_pjs(PJS_SLIDEHTML, [ hurl ], 
 				function(data) {
 					res.writeHead(200);
@@ -127,7 +127,7 @@ http.createServer(
 				}
 				
 				if (genpdf) {
-					hurl = "http://" + config.HOSTNAME + "/" + urlp.pathname.replace(".pdf", ".html") + "#/1/v4";
+                            hurl = "http://" + config.HOSTNAME + ":" + config.SERVER_PORT + "/" + urlp.pathname.replace(".pdf", ".html") + "#/1/v4";
                         		config.execute_pjs(PJS_PRINTPDF, [ hurl, fpdf ],
                                 		function(data) {
 							// set the modification date of pdf file to be the same as the html file


### PR DESCRIPTION
Hi,
As you requested on the lecture, I looked into the code and made a quick edit to generate pdfs with one slide per page. Also I fixed pdf generation when server listens on non-standard port and allowed pdf generating on all html files.

P.S. It would be better to make this functionality optional but I couldn't figure out how to do that with current system of extensions/views.

Gregy - gregope2@fit.cvut.cz
